### PR TITLE
Revamp global styles and responsive layout

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -1,154 +1,314 @@
+:root {
+    --color-primary: #4c51bf;
+    --color-primary-strong: #373bb3;
+    --color-surface: #ffffff;
+    --color-surface-muted: #f4f5fb;
+    --color-border: #e1e4f2;
+    --color-text: #1f2430;
+    --color-text-muted: #555b6a;
+    --color-accent: #f97316;
+
+    --font-base: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+    --font-heading: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+
+    --space-2xs: 4px;
+    --space-xs: 8px;
+    --space-sm: 12px;
+    --space-md: 16px;
+    --space-lg: 24px;
+    --space-xl: 32px;
+    --space-2xl: 48px;
+
+    --shadow-sm: 0 1px 3px rgba(31, 36, 48, 0.12);
+    --shadow-md: 0 10px 35px rgba(55, 59, 179, 0.12);
+}
+
+* {
+    box-sizing: border-box;
+}
+
 body {
     margin: 0;
-    font-family: Arial, sans-serif;
-    background: #f5f5f5;
+    font-family: var(--font-base);
+    color: var(--color-text);
+    background: var(--color-surface-muted);
+    line-height: 1.6;
+}
+
+a {
+    color: var(--color-primary);
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+a:hover {
+    color: var(--color-primary-strong);
+    text-decoration: underline;
+}
+
+h1, h2, h3 {
+    font-family: var(--font-heading);
+    margin: 0 0 var(--space-sm);
+    color: var(--color-text);
+    line-height: 1.2;
+}
+
+h1 {
+    font-size: clamp(26px, 4vw, 34px);
+    font-weight: 700;
+}
+
+h2 {
+    font-size: clamp(22px, 3vw, 28px);
+    font-weight: 700;
+}
+
+h3 {
+    font-size: clamp(18px, 2.5vw, 22px);
+    font-weight: 600;
+}
+
+p {
+    margin: 0 0 var(--space-sm);
+    color: var(--color-text-muted);
 }
 
 .container {
-    max-width: 900px;
+    width: 100%;
     margin: 0 auto;
-    padding: 0 16px;
+    padding: 0 var(--space-md);
+    max-width: 100%;
+}
+
+@media (min-width: 640px) {
+    .container {
+        max-width: 640px;
+    }
+}
+
+@media (min-width: 768px) {
+    .container {
+        max-width: 768px;
+    }
+}
+
+@media (min-width: 1024px) {
+    .container {
+        max-width: 1024px;
+    }
+}
+
+@media (min-width: 1280px) {
+    .container {
+        max-width: 1180px;
+    }
 }
 
 .header {
-    background: #333;
-    color: #fff;
+    background: var(--color-surface);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    box-shadow: var(--shadow-sm);
 }
 
 .header__content {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 12px 0;
+    padding: var(--space-sm) 0;
+    gap: var(--space-sm);
 }
 
 .logo {
-    color: #fff;
-    text-decoration: none;
-    font-weight: bold;
+    color: var(--color-text);
+    font-weight: 700;
+    letter-spacing: 0.3px;
+    font-size: 18px;
+}
+
+.nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    align-items: center;
+    justify-content: flex-end;
 }
 
 .nav__link {
-    color: #fff;
+    color: var(--color-text);
+    font-weight: 500;
+    padding: 6px 10px;
+    border-radius: 8px;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav__link:hover {
+    background: var(--color-surface-muted);
+    color: var(--color-primary-strong);
     text-decoration: none;
-    margin-left: 12px;
 }
 
 .main {
-    padding: 20px 0 40px;
-    min-height: calc(100vh - 120px);
+    padding: var(--space-lg) 0 var(--space-2xl);
+    min-height: calc(100vh - 140px);
 }
 
 .footer {
-    background: #eee;
-    padding: 10px 0;
+    background: var(--color-surface);
+    padding: var(--space-md) 0;
     text-align: center;
     font-size: 14px;
+    color: var(--color-text-muted);
+    border-top: 1px solid var(--color-border);
+}
+
+.cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: var(--space-md);
+    margin-top: var(--space-md);
 }
 
 .card {
-    background: #fff;
-    padding: 12px;
-    border-radius: 6px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    background: var(--color-surface);
+    padding: var(--space-md);
+    border-radius: 12px;
+    box-shadow: var(--shadow-md);
     display: flex;
-    gap: 10px;
-    align-items: stretch;   /* чтобы обложка была ограничена по высоте */
+    flex-direction: row;
+    gap: var(--space-md);
+    align-items: stretch;
+    border: 1px solid var(--color-border);
 }
 
-/* Обложка в карточке каталога */
 .card__cover {
-    flex: 0 0 80px;         /* фиксированная ширина "колонки" под обложку */
-    width: 80px;
-    height: 110px;
-    border-radius: 4px;
-    overflow: hidden;       /* главное: ничего не вылезает за рамки */
-    background: #eee;
+    flex: 0 0 90px;
+    width: 90px;
+    height: 120px;
+    border-radius: 8px;
+    overflow: hidden;
+    background: var(--color-surface-muted);
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: 11px;
     text-align: center;
-    padding: 4px;
-    box-sizing: border-box;
+    padding: 6px;
+    color: var(--color-text-muted);
+    border: 1px dashed var(--color-border);
 }
 
 .card__cover img {
     display: block;
     width: 100%;
     height: 100%;
-    object-fit: cover;      /* кадрирование по размеру блока */
-}
-
-.card__cover_placeholder {
-    color: #777;
+    object-fit: cover;
 }
 
 .card__body {
     flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+}
+
+.card__body h3 {
+    margin: 0;
 }
 
 .search {
-    margin: 12px 0 20px;
-    background: #fff;
-    padding: 10px;
-    border-radius: 6px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    margin: var(--space-sm) 0 var(--space-lg);
+    background: var(--color-surface);
+    padding: var(--space-md);
+    border-radius: 12px;
+    box-shadow: var(--shadow-sm);
+    border: 1px solid var(--color-border);
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: var(--space-sm);
 }
 
 .search__row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px 16px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: var(--space-sm);
     align-items: center;
 }
 
 .search__row label {
     font-size: 14px;
+    color: var(--color-text-muted);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
 }
 
 .search__row input,
 .search__row select {
-    padding: 4px 6px;
+    padding: 8px 10px;
     font-size: 14px;
+    border-radius: 8px;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface-muted);
+    color: var(--color-text);
+}
+
+button {
+    cursor: pointer;
+    border: none;
+    border-radius: 10px;
+    padding: 10px 14px;
+    background: var(--color-primary);
+    color: #fff;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+    transition: background 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: var(--shadow-sm);
+}
+
+button:hover {
+    background: var(--color-primary-strong);
+}
+
+button:disabled {
+    opacity: 0.6;
+    cursor: default;
+    box-shadow: none;
 }
 
 .form {
     display: flex;
     flex-direction: column;
-    gap: 10px;
-    max-width: 360px;
+    gap: var(--space-sm);
+    max-width: 420px;
 }
 
 .form input {
     width: 100%;
-    padding: 6px 8px;
-    box-sizing: border-box;
-}
-
-.form button {
-    padding: 8px 10px;
+    padding: 10px 12px;
+    border-radius: 10px;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
 }
 
 .message {
-    margin-top: 10px;
+    margin-top: var(--space-xs);
     font-size: 14px;
+    color: var(--color-text-muted);
 }
 
 .message_error {
-    color: #b00020;
+    color: #b91c1c;
 }
 
-
 .profile-card {
-    max-width: 400px;
-    background: #fff;
-    padding: 16px;
-    border-radius: 6px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    max-width: 480px;
+    background: var(--color-surface);
+    padding: var(--space-lg);
+    border-radius: 12px;
+    box-shadow: var(--shadow-md);
+    border: 1px solid var(--color-border);
 }
 
 .profile-card p {
@@ -158,55 +318,59 @@ body {
 .table {
     width: 100%;
     border-collapse: collapse;
-    margin-top: 8px;
+    margin-top: var(--space-sm);
+    background: var(--color-surface);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: var(--shadow-sm);
 }
 
 .table th,
 .table td {
-    padding: 6px 8px;
-    border-bottom: 1px solid #ddd;
+    padding: var(--space-sm) var(--space-md);
+    border-bottom: 1px solid var(--color-border);
     text-align: left;
+    font-size: 14px;
 }
 
 .table th {
-    background: #f5f5f5;
+    background: var(--color-surface-muted);
+    color: var(--color-text);
+    font-weight: 600;
 }
 
 .qty-input {
-    width: 60px;
-}
-
-.message {
-    margin-top: 8px;
-    font-size: 14px;
-}
-
-.message_error {
-    color: #b91c1c;
-}
-
-
-button {
-    cursor: pointer;
+    width: 70px;
+    padding: 8px 10px;
+    border-radius: 8px;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface-muted);
 }
 
 .pagination {
-    margin-top: 12px;
+    margin-top: var(--space-md);
     display: flex;
     align-items: center;
-    gap: 8px;
-}
-
-.pagination button {
-    padding: 4px 8px;
-    font-size: 14px;
-}
-
-.pagination button[disabled] {
-    opacity: 0.5;
-    cursor: default;
+    gap: var(--space-sm);
 }
 
 #page-info {
     font-size: 14px;
+    color: var(--color-text-muted);
+}
+
+@media (max-width: 640px) {
+    .header__content {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .card {
+        flex-direction: column;
+    }
+
+    .card__cover {
+        width: 100%;
+        max-width: 160px;
+    }
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,6 +2,7 @@
 <html lang="ru">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bookstore</title>
     <link rel="stylesheet" href="/static/css/styles.css">
 </head>
@@ -12,9 +13,9 @@
         <nav class="nav">
             <a href="/" class="nav__link">Каталог</a>
             <a href="/cart" class="nav__link">Корзина</a>
-            <a href="/orders">Мои заказы</a>
-            <a href="/profile">Профиль</a>
-            <a href="/admin">Админ-панель</a>
+            <a href="/orders" class="nav__link">Мои заказы</a>
+            <a href="/profile" class="nav__link">Профиль</a>
+            <a href="/admin" class="nav__link">Админ-панель</a>
             <a href="/login" class="nav__link" id="nav-login-link">Войти</a>
             <a href="/register" class="nav__link" id="nav-register-link">Регистрация</a>
         </nav>


### PR DESCRIPTION
## Summary
- add design tokens for colors, spacing, typography, and shadows to the global stylesheet
- rebuild container and card grid layout with mobile-first breakpoints and refreshed UI styling
- update typography defaults and navigation link styling for consistent presentation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c430050fc832387b5370a2570f29c)