### PR TITLE
Enhance catalog filters and search UX

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -460,6 +460,191 @@ body.drawer-open {
     gap: var(--space-xs);
 }
 
+.catalog-filters {
+    margin: var(--space-sm) 0 var(--space-lg);
+    background: var(--color-surface);
+    padding: var(--space-lg);
+    border-radius: 14px;
+    box-shadow: var(--shadow-sm);
+    border: 1px solid var(--color-border);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+}
+
+.catalog-filters__top {
+    display: flex;
+    gap: var(--space-md);
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}
+
+.catalog-filters__intro {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
+    max-width: 680px;
+}
+
+.catalog-filters__title {
+    margin: 0;
+    font-weight: 700;
+    color: var(--color-text);
+}
+
+.catalog-filters__hint {
+    margin: 0;
+    color: var(--color-text-muted);
+    font-size: 14px;
+}
+
+.catalog-filters__actions {
+    display: flex;
+    gap: var(--space-xs);
+    align-items: center;
+}
+
+.catalog-filters__toggle {
+    display: none;
+}
+
+.catalog-filters__search {
+    width: 100%;
+}
+
+.search-input {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 42px 1fr auto;
+    align-items: center;
+    gap: var(--space-xs);
+    background: var(--color-surface-muted);
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 8px 10px 8px 12px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-input:is(:focus-within, .is-filled) {
+    border-color: rgba(76, 81, 191, 0.35);
+    box-shadow: 0 0 0 4px rgba(76, 81, 191, 0.08);
+}
+
+.search-input input {
+    border: none;
+    background: transparent;
+    padding: 10px 4px;
+    font-size: 15px;
+    width: 100%;
+}
+
+.search-input input:focus {
+    outline: none;
+}
+
+.search-input__icon {
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-muted);
+}
+
+.search-input__icon svg {
+    width: 20px;
+    height: 20px;
+    fill: currentColor;
+}
+
+.search-input__submit {
+    padding-inline: 16px;
+    box-shadow: none;
+}
+
+.catalog-filters__body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+}
+
+.filter-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--space-sm);
+}
+
+.filter-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
+    font-size: 14px;
+    color: var(--color-text-muted);
+}
+
+.filter-field__label {
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.filter-field input,
+.filter-field select {
+    padding: 10px 12px;
+    font-size: 14px;
+    border-radius: 10px;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface-muted);
+    color: var(--color-text);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.filter-field input:focus,
+.filter-field select:focus {
+    outline: none;
+    border-color: rgba(76, 81, 191, 0.35);
+    box-shadow: 0 0 0 3px rgba(76, 81, 191, 0.08);
+}
+
+.filter-quick {
+    background: var(--color-surface-muted);
+    border: 1px dashed var(--color-border);
+    padding: var(--space-sm);
+    border-radius: 12px;
+    display: grid;
+    gap: var(--space-xs);
+}
+
+.filter-quick__label {
+    font-weight: 700;
+    color: var(--color-text);
+}
+
+.filter-checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    font-size: 14px;
+    color: var(--color-text);
+}
+
+.filter-checkbox input {
+    width: 16px;
+    height: 16px;
+}
+
+.search {
+    margin: var(--space-sm) 0 var(--space-lg);
+    background: var(--color-surface);
+    padding: var(--space-md);
+    border-radius: 12px;
+    box-shadow: var(--shadow-sm);
+    border: 1px solid var(--color-border);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+}
+
 .search {
     margin: var(--space-sm) 0 var(--space-lg);
     background: var(--color-surface);
@@ -676,6 +861,35 @@ button:disabled,
     color: var(--color-text-muted);
 }
 
+.empty-state {
+    margin-top: var(--space-md);
+    padding: var(--space-xl);
+    text-align: center;
+    background: var(--color-surface);
+    border-radius: 14px;
+    border: 1px dashed var(--color-border);
+    color: var(--color-text-muted);
+    display: grid;
+    gap: var(--space-sm);
+}
+
+.empty-state__title {
+    margin: 0;
+    font-weight: 700;
+    color: var(--color-text);
+}
+
+.empty-state__filters {
+    font-size: 14px;
+    color: var(--color-text-muted);
+}
+
+.cards__loading {
+    text-align: center;
+    color: var(--color-text-muted);
+    padding: var(--space-md);
+}
+
 @media (max-width: 1024px) {
     .header__actions {
         display: none;
@@ -696,6 +910,10 @@ button:disabled,
 
     .header__search_mobile {
         display: flex;
+    }
+
+    .catalog-filters__top {
+        align-items: flex-start;
     }
 }
 
@@ -720,5 +938,38 @@ button:disabled,
         width: 100%;
         max-width: 200px;
         margin: 0 auto;
+    }
+
+    .catalog-filters {
+        padding: var(--space-md);
+    }
+
+    .catalog-filters__actions {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .catalog-filters__toggle {
+        display: inline-flex;
+    }
+
+    .catalog-filters__body {
+        display: none;
+    }
+
+    .catalog-filters.is-open .catalog-filters__body {
+        display: flex;
+    }
+
+    .filter-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .search-input {
+        grid-template-columns: 32px 1fr;
+    }
+
+    .search-input__submit {
+        display: none;
     }
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -3,66 +3,105 @@
 {% block content %}
 <h1>Каталог книг</h1>
 
-<div class="search">
-    <div class="search__row">
-        <input type="text" id="search-input" placeholder="Поиск по названию">
-        <button id="search-btn">Искать</button>
+<div class="catalog-filters">
+    <div class="catalog-filters__top">
+        <div class="catalog-filters__intro">
+            <p class="catalog-filters__title">Найдите нужную книгу по ключевым словам и параметрам.</p>
+            <p class="catalog-filters__hint">Фильтры работают сразу: изменяйте значения, и результаты обновятся автоматически.</p>
+        </div>
+        <div class="catalog-filters__actions">
+            <button id="filters-toggle" class="btn btn_secondary catalog-filters__toggle" type="button" aria-expanded="false" aria-controls="filters-collapse">Фильтры</button>
+            <button id="search-reset-btn" class="btn btn_ghost">Сбросить</button>
+        </div>
     </div>
 
-    <div class="search__row">
-        <label>
-            Жанр:
-            <select id="filter-genre">
-                <option value="">Все</option>
-            </select>
-        </label>
-
-        <label>
-            Автор:
-            <select id="filter-author">
-                <option value="">Все</option>
-            </select>
-        </label>
-
-        <label>
-            Цена от:
-            <input type="number" id="filter-min-price" min="0">
-        </label>
-
-        <label>
-            до:
-            <input type="number" id="filter-max-price" min="0">
-        </label>
+    <div class="catalog-filters__search">
+        <div class="search-input" data-search-wrapper>
+            <span class="search-input__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+                    <path d="M15.5 14h-.79l-.28-.27a6.471 6.471 0 0 0 1.57-4.23A6.5 6.5 0 1 0 9.5 15c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l4.25 4.25a1 1 0 0 0 1.42-1.42L15.5 14Zm-6 0a4.5 4.5 0 1 1 0-9 4.5 4.5 0 0 1 0 9Z" />
+                </svg>
+            </span>
+            <input type="text" id="search-input" placeholder="Название, автор или ключевое слово" aria-label="Поиск по каталогу">
+            <button id="search-btn" class="btn btn_secondary search-input__submit" type="button">Искать</button>
+        </div>
     </div>
 
-    <div class="search__row">
-        <label>
-            Год от:
-            <input type="number" id="filter-min-year">
-        </label>
+    <div class="catalog-filters__body" id="filters-collapse">
+        <div class="filter-grid">
+            <label class="filter-field">
+                <span class="filter-field__label">Жанр</span>
+                <select id="filter-genre">
+                    <option value="">Все жанры</option>
+                </select>
+            </label>
 
-        <label>
-            до:
-            <input type="number" id="filter-max-year">
-        </label>
+            <label class="filter-field">
+                <span class="filter-field__label">Автор</span>
+                <select id="filter-author">
+                    <option value="">Все авторы</option>
+                </select>
+            </label>
 
-        <label>
-            Сортировка:
-            <select id="filter-order">
-                <option value="">По умолчанию</option>
-                <option value="price_asc">Цена по возрастанию</option>
-                <option value="price_desc">Цена по убыванию</option>
-                <option value="year_desc">Сначала новые</option>
-                <option value="year_asc">Сначала старые</option>
-                <option value="title_asc">Название A→Я</option>
-                <option value="title_desc">Название Я→A</option>
-            </select>
-        </label>
+            <label class="filter-field">
+                <span class="filter-field__label">Цена от</span>
+                <input type="number" id="filter-min-price" min="0" placeholder="0">
+            </label>
 
-        <button id="search-reset-btn">Сбросить</button>
+            <label class="filter-field">
+                <span class="filter-field__label">до</span>
+                <input type="number" id="filter-max-price" min="0" placeholder="3000">
+            </label>
+        </div>
+
+        <div class="filter-grid">
+            <label class="filter-field">
+                <span class="filter-field__label">Год от</span>
+                <input type="number" id="filter-min-year" placeholder="2000">
+            </label>
+
+            <label class="filter-field">
+                <span class="filter-field__label">до</span>
+                <input type="number" id="filter-max-year" placeholder="2024">
+            </label>
+
+            <label class="filter-field">
+                <span class="filter-field__label">Сортировка</span>
+                <select id="filter-order">
+                    <option value="">По умолчанию</option>
+                    <option value="price_asc">Цена по возрастанию</option>
+                    <option value="price_desc">Цена по убыванию</option>
+                    <option value="year_desc">Сначала новые</option>
+                    <option value="year_asc">Сначала старые</option>
+                    <option value="title_asc">Название A→Я</option>
+                    <option value="title_desc">Название Я→A</option>
+                </select>
+            </label>
+
+            <div class="filter-quick">
+                <span class="filter-quick__label">Быстрые фильтры</span>
+                <label class="filter-checkbox">
+                    <input type="checkbox" id="filter-quick-new">
+                    <span>Новинки после 2015</span>
+                </label>
+                <label class="filter-checkbox">
+                    <input type="checkbox" id="filter-quick-budget">
+                    <span>Бюджетные до 500 ₽</span>
+                </label>
+                <label class="filter-checkbox">
+                    <input type="checkbox" id="filter-quick-premium">
+                    <span>Коллекционные от 1500 ₽</span>
+                </label>
+                <label class="filter-checkbox">
+                    <input type="checkbox" id="filter-quick-classic">
+                    <span>Классика до 1990</span>
+                </label>
+            </div>
+        </div>
     </div>
 </div>
 
+<div id="books-empty-state" class="empty-state" hidden></div>
 <div id="books-list" class="cards"></div>
 
 <div class="pagination">


### PR DESCRIPTION
## Summary
- add richer catalog filter panel with quick filters, collapse on mobile, and updated layout
- improve search field visuals, placeholder, and debounce-driven updates
- connect filters to live results with better empty states and reset handling

## Testing
- pytest -q *(fails: missing python-multipart dependency)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c4ad13b448323a2157d0cdf47401a)