### PR TITLE
Add relation selection when creating books

### DIFF
--- a/app/repositories/author_repository.py
+++ b/app/repositories/author_repository.py
@@ -14,5 +14,12 @@ class AuthorRepository(BaseRepository[Author]):
     def get_by_id(self, author_id: int) -> Optional[Author]:
         return self.get(author_id)
 
+    def get_by_name(self, full_name: str) -> Optional[Author]:
+        return (
+            self.db.query(Author)
+            .filter(Author.full_name == full_name)
+            .first()
+        )
+
     def list_all(self) -> List[Author]:
         return self.list()

--- a/app/repositories/publisher_repository.py
+++ b/app/repositories/publisher_repository.py
@@ -14,5 +14,12 @@ class PublisherRepository(BaseRepository[Publisher]):
     def get_by_id(self, publisher_id: int) -> Optional[Publisher]:
         return self.get(publisher_id)
 
+    def get_by_name(self, name: str) -> Optional[Publisher]:
+        return (
+            self.db.query(Publisher)
+            .filter(Publisher.name == name)
+            .first()
+        )
+
     def list_all(self) -> List[Publisher]:
         return self.list()

--- a/app/schemas/book.py
+++ b/app/schemas/book.py
@@ -2,7 +2,7 @@
 from decimal import Decimal
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict  # добавили ConfigDict
+from pydantic import BaseModel, ConfigDict, Field  # добавили ConfigDict
 
 
 class BookBase(BaseModel):
@@ -13,8 +13,11 @@ class BookBase(BaseModel):
     pages: Optional[int] = None
     isbn: Optional[str] = None
     genre_id: Optional[int] = None
+    genre_name: Optional[str] = None
     publisher_id: Optional[int] = None
-    author_ids: List[int] = []  # список id авторов
+    publisher_name: Optional[str] = None
+    author_ids: List[int] = Field(default_factory=list)  # список id авторов
+    author_names: List[str] = Field(default_factory=list)
     cover_image: Optional[str] = None  # URL/путь к обложке
 
 
@@ -30,8 +33,11 @@ class BookUpdate(BaseModel):
     pages: Optional[int] = None
     isbn: Optional[str] = None
     genre_id: Optional[int] = None
+    genre_name: Optional[str] = None
     publisher_id: Optional[int] = None
+    publisher_name: Optional[str] = None
     author_ids: Optional[List[int]] = None
+    author_names: Optional[List[str]] = None
     cover_image: Optional[str] = None  # на случай ручного обновления
 
 

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -38,6 +38,21 @@
                     Кол-во страниц
                     <input type="number" name="pages">
                 </label>
+                <label>
+                    Жанр
+                    <input type="text" name="genre_name" list="admin-genre-options" placeholder="Начните вводить жанр">
+                    <datalist id="admin-genre-options"></datalist>
+                </label>
+                <label>
+                    Авторы (через запятую)
+                    <input type="text" name="author_names" list="admin-author-options" placeholder="Например: Имя Автора, Другой Автор">
+                    <datalist id="admin-author-options"></datalist>
+                </label>
+                <label>
+                    Издательство
+                    <input type="text" name="publisher_name" list="admin-publisher-options" placeholder="Начните вводить издательство">
+                    <datalist id="admin-publisher-options"></datalist>
+                </label>
                 <!-- НОВОЕ ПОЛЕ -->
                 <label>
                     Обложка

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ jinja2
 pytest
 httpx
 email-validator
+python-multipart


### PR DESCRIPTION
## Summary
- allow creating books with genre, author, and publisher names, creating related records when missing
- enhance admin UI to suggest existing relations and pass selected names to the API
- add coverage for relation auto-creation and include python-multipart dependency

## Testing
- pytest -q *(fails: missing python-multipart package; installation blocked by environment proxy)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c555b6ef483239eb4e8bdf5df847c)