### PR TITLE
Restyle admin panel layout and integrate cover edits

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -977,6 +977,266 @@ button:disabled,
     box-shadow: var(--shadow-sm);
 }
 
+.admin-page {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+    padding-block: var(--space-lg);
+}
+
+.admin-hero {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: var(--space-lg);
+    background: linear-gradient(120deg, rgba(76, 81, 191, 0.08), rgba(249, 115, 22, 0.06));
+    border: 1px solid rgba(76, 81, 191, 0.15);
+}
+
+.admin-hero__meta {
+    display: flex;
+    gap: var(--space-xs);
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.admin-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    border-radius: 999px;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-weight: 600;
+    box-shadow: var(--shadow-sm);
+}
+
+.admin-status {
+    margin: 0;
+    color: var(--color-text-muted);
+}
+
+.admin-layout {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: var(--space-lg);
+    align-items: start;
+}
+
+.admin-sidebar {
+    position: sticky;
+    top: 88px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+}
+
+.admin-sidebar__title {
+    margin: 0;
+    font-weight: 700;
+    color: var(--color-text);
+}
+
+.admin-nav {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+}
+
+.admin-nav__btn {
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 12px 14px;
+    border-radius: 12px;
+    text-align: left;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.admin-nav__btn:hover {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+    box-shadow: 0 8px 20px rgba(76, 81, 191, 0.12);
+}
+
+.admin-nav__btn.is-active {
+    background: rgba(76, 81, 191, 0.08);
+    border-color: var(--color-primary);
+    color: var(--color-primary-strong);
+    font-weight: 700;
+}
+
+.admin-sections {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+}
+
+.admin-section__header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
+    margin-bottom: var(--space-md);
+}
+
+.admin-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+    gap: var(--space-lg);
+}
+
+.admin-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 14px;
+    padding: var(--space-lg);
+    box-shadow: var(--shadow-sm);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+}
+
+.admin-card_inline {
+    max-width: 640px;
+}
+
+.admin-card__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-md);
+    flex-wrap: wrap;
+}
+
+.admin-form {
+    max-width: 100%;
+}
+
+.admin-form .form__actions {
+    align-items: flex-start;
+}
+
+.admin-form .form__actions .form__message {
+    margin: 0;
+}
+
+.admin-form__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: var(--space-md);
+}
+
+.admin-table-wrapper {
+    overflow-x: auto;
+}
+
+.admin-table td:first-child,
+.admin-table th:first-child {
+    width: 80px;
+}
+
+.admin-book-row__title {
+    font-weight: 700;
+    margin-bottom: 4px;
+    color: var(--color-text);
+}
+
+.admin-cover-thumb {
+    width: 72px;
+    height: 96px;
+    border-radius: 12px;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface-muted);
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+}
+
+.admin-cover-thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.admin-cover-thumb_empty {
+    color: var(--color-text-muted);
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.admin-edit-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--space-md);
+}
+
+.admin-edit-grid_wide {
+    grid-template-columns: minmax(220px, 2fr) minmax(240px, 1fr);
+}
+
+.admin-cover-block {
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: var(--space-md);
+    padding: var(--space-md);
+    border-radius: 12px;
+    border: 1px dashed var(--color-border);
+    background: var(--color-surface-muted);
+    align-items: start;
+}
+
+.admin-cover-block__preview {
+    display: grid;
+    place-items: center;
+}
+
+.admin-cover-block__controls {
+    display: flex;
+    gap: var(--space-sm);
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.admin-edit-actions {
+    gap: var(--space-xs);
+}
+
+.admin-edit-actions__buttons {
+    display: flex;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+}
+
+@media (max-width: 1100px) {
+    .admin-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .admin-sidebar {
+        position: static;
+    }
+
+    .admin-nav {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    .admin-nav__btn {
+        flex: 1 1 200px;
+    }
+
+    .admin-hero {
+        flex-direction: column;
+    }
+
+    .admin-cover-block {
+        grid-template-columns: 1fr;
+    }
+}
+
 .empty-state {
     text-align: center;
     padding: var(--space-xl) var(--space-lg);

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1046,7 +1046,7 @@ function initAdminPage() {
                 return false;
             }
             checkMsg.style.display = "none";
-            content.style.display = "block";
+            content.style.display = "";
             return true;
         } catch (e) {
             checkMsg.textContent = "Необходимо войти как администратор";
@@ -1057,6 +1057,10 @@ function initAdminPage() {
     function switchSection(name) {
         document.querySelectorAll(".admin-section").forEach((sec) => {
             sec.style.display = sec.id === "admin-section-" + name ? "block" : "none";
+        });
+
+        root.querySelectorAll(".admin-nav__btn").forEach((btn) => {
+            btn.classList.toggle("is-active", btn.getAttribute("data-section") === name);
         });
     }
 
@@ -1122,93 +1126,109 @@ function initAdminPage() {
                             return ch;
                     }
                 });
-            let html = `<table class="table">
+            let html = `<div class="admin-table-wrapper"><table class="table admin-table">
                 <thead>
                     <tr>
                         <th>ID</th>
-                        <th>Обложка</th>
-                        <th>Название</th>
+                        <th>Книга</th>
                         <th>Цена</th>
-                        <th>Обложка (загрузка)</th>
-                        <th></th>
+                        <th>Обложка</th>
+                        <th class="table__actions"></th>
                     </tr>
                 </thead>
                 <tbody>
             `;
             books.forEach((b) => {
                 const cover = b.cover_image
-                    ? `<img src="${b.cover_image}" alt="Обложка" style="max-width:60px; max-height:80px;">`
-                    : `<span class="small-muted">нет</span>`;
+                    ? `<div class="admin-cover-thumb"><img src="${b.cover_image}" alt="Обложка ${escapeHtml(b.title)}"></div>`
+                    : `<div class="admin-cover-thumb admin-cover-thumb_empty">Нет</div>`;
                 const authorString = (b.author_names || []).join(", ");
                 html += `
                     <tr data-book-id="${b.book_id}">
-                        <td>${b.book_id}</td>
+                        <td class="table__num">${b.book_id}</td>
+                        <td>
+                            <div class="admin-book-row">
+                                <div class="admin-book-row__title">${escapeHtml(b.title)}</div>
+                                <div class="small-muted">${escapeHtml(authorString) || "Без авторов"}</div>
+                            </div>
+                        </td>
+                        <td class="table__num">${b.price} ₽</td>
                         <td>${cover}</td>
-                        <td>
-                            ${escapeHtml(b.title)}
-                            <div class="small-muted">${escapeHtml(authorString) || "Без авторов"}</div>
-                        </td>
-                        <td>${b.price} ₽</td>
-                        <td>
-                            <input type="file" class="admin-cover-file" accept="image/*">
-                            <button class="admin-cover-upload">Загрузить</button>
-                        </td>
                         <td class="table__actions">
                             <button class="btn btn_ghost btn_sm admin-book-edit-toggle">Редактировать</button>
                             <button data-book-id="${b.book_id}" class="btn btn_danger btn_sm admin-book-delete">Удалить</button>
                         </td>
                     </tr>
                     <tr class="admin-book-edit-row" data-book-id="${b.book_id}" style="display: none;">
-                        <td colspan="6">
+                        <td colspan="5">
                             <form class="form admin-book-edit-form" data-book-id="${b.book_id}">
-                                <div class="form__row">
-                                    <label>Название
-                                        <input type="text" name="title" value="${escapeHtml(b.title)}" required>
-                                    </label>
+                                <div class="admin-edit-grid">
+                                    <div class="form__field">
+                                        <label class="form__label">Название</label>
+                                        <input class="input" type="text" name="title" value="${escapeHtml(b.title)}" required>
+                                    </div>
+                                    <div class="form__field">
+                                        <label class="form__label">Цена</label>
+                                        <input class="input" type="number" name="price" step="0.01" min="0" value="${b.price}" required>
+                                    </div>
+                                    <div class="form__field">
+                                        <label class="form__label">Год</label>
+                                        <input class="input" type="number" name="publication_year" value="${b.publication_year || ""}" placeholder="Например, 2024">
+                                    </div>
+                                    <div class="form__field">
+                                        <label class="form__label">Страниц</label>
+                                        <input class="input" type="number" name="pages" value="${b.pages || ""}">
+                                    </div>
+                                    <div class="form__field">
+                                        <label class="form__label">ISBN</label>
+                                        <input class="input" type="text" name="isbn" value="${escapeHtml(b.isbn || "")}" placeholder="ISBN">
+                                    </div>
+                                    <div class="form__field">
+                                        <label class="form__label">Жанр</label>
+                                        <input class="input" type="text" name="genre_name" list="admin-genre-options" value="${escapeHtml(b.genre_name || "")}" placeholder="Название жанра">
+                                    </div>
+                                    <div class="form__field">
+                                        <label class="form__label">Издательство</label>
+                                        <input class="input" type="text" name="publisher_name" list="admin-publisher-options" value="${escapeHtml(b.publisher_name || "")}" placeholder="Название издательства">
+                                    </div>
+                                    <div class="form__field">
+                                        <label class="form__label">Авторы</label>
+                                        <input class="input" type="text" name="author_names" list="admin-author-options" value="${escapeHtml(authorString)}" placeholder="Автор1, Автор2">
+                                        <p class="form__hint">Укажите несколько авторов через запятую</p>
+                                    </div>
                                 </div>
-                                <div class="form__row">
-                                    <label>Цена
-                                        <input type="number" name="price" step="0.01" min="0" value="${b.price}" required>
-                                    </label>
-                                    <label>Год
-                                        <input type="number" name="publication_year" value="${b.publication_year || ""}" placeholder="Например, 2024">
-                                    </label>
-                                    <label>Страниц
-                                        <input type="number" name="pages" value="${b.pages || ""}">
-                                    </label>
+                                <div class="admin-edit-grid admin-edit-grid_wide">
+                                    <div class="form__field">
+                                        <label class="form__label">Описание</label>
+                                        <textarea class="input" name="description" rows="3" placeholder="Описание книги">${escapeHtml(b.description || "")}</textarea>
+                                    </div>
+                                    <div class="admin-cover-block">
+                                        <div class="admin-cover-block__preview">
+                                            ${cover}
+                                        </div>
+                                        <div class="admin-cover-block__fields">
+                                            <label class="form__label">Обложка</label>
+                                            <div class="admin-cover-block__controls">
+                                                <input class="input admin-cover-input" type="file" accept="image/*">
+                                                <button type="button" class="btn btn_ghost btn_sm admin-cover-submit">Загрузить обложку</button>
+                                            </div>
+                                            <p class="form__hint">PNG или JPG, до 5 МБ</p>
+                                        </div>
+                                    </div>
                                 </div>
-                                <div class="form__row">
-                                    <label>ISBN
-                                        <input type="text" name="isbn" value="${escapeHtml(b.isbn || "")}" placeholder="ISBN">
-                                    </label>
+                                <div class="form__actions admin-edit-actions">
+                                    <div class="admin-edit-actions__buttons">
+                                        <button type="submit" class="btn btn_sm">Сохранить</button>
+                                        <button type="button" class="btn btn_ghost btn_sm admin-book-edit-toggle">Свернуть</button>
+                                    </div>
+                                    <p class="form__message admin-book-edit-msg"></p>
                                 </div>
-                                <div class="form__row">
-                                    <label>Жанр
-                                        <input type="text" name="genre_name" list="admin-genre-options" value="${escapeHtml(b.genre_name || "")}" placeholder="Название жанра">
-                                    </label>
-                                    <label>Издательство
-                                        <input type="text" name="publisher_name" list="admin-publisher-options" value="${escapeHtml(b.publisher_name || "")}" placeholder="Название издательства">
-                                    </label>
-                                    <label>Авторы
-                                        <input type="text" name="author_names" list="admin-author-options" value="${escapeHtml(authorString)}" placeholder="Автор1, Автор2">
-                                    </label>
-                                </div>
-                                <div class="form__row">
-                                    <label>Описание
-                                        <textarea name="description" rows="3" placeholder="Описание книги">${escapeHtml(b.description || "")}</textarea>
-                                    </label>
-                                </div>
-                                <div class="form__actions">
-                                    <button type="submit" class="btn btn_primary btn_sm">Сохранить изменения</button>
-                                    <button type="button" class="btn btn_ghost btn_sm admin-book-edit-toggle">Свернуть</button>
-                                </div>
-                                <div class="message admin-book-edit-msg"></div>
                             </form>
                         </td>
                     </tr>
                 `;
             });
-            html += "</tbody></table>";
+            html += "</tbody></table></div>";
             el.innerHTML = html;
 
             // удаление книг
@@ -1325,21 +1345,27 @@ function initAdminPage() {
                 });
             });
 
-            // загрузка обложки
-            el.querySelectorAll(".admin-cover-upload").forEach((btn) => {
-                btn.addEventListener("click", async (e) => {
-                    const tr = e.target.closest("tr");
-                    const id = tr.getAttribute("data-book-id");
-                    const fileInput = tr.querySelector(".admin-cover-file");
-                    if (!fileInput.files || !fileInput.files[0]) {
-                        alert("Выберите файл");
+            el.querySelectorAll(".admin-book-edit-form").forEach((form) => {
+                const coverBtn = form.querySelector(".admin-cover-submit");
+                const coverInput = form.querySelector(".admin-cover-input");
+                const msg = form.querySelector(".admin-book-edit-msg");
+                const bookId = form.getAttribute("data-book-id");
+
+                coverBtn?.addEventListener("click", async () => {
+                    msg.textContent = "";
+                    msg.classList.remove("message_error");
+
+                    if (!coverInput?.files || !coverInput.files[0]) {
+                        msg.textContent = "Выберите файл обложки";
+                        msg.classList.add("message_error");
                         return;
                     }
+
                     const formData = new FormData();
-                    formData.append("file", fileInput.files[0]);
+                    formData.append("file", coverInput.files[0]);
 
                     try {
-                        await fetch(`/api/admin/books/${id}/cover`, {
+                        await fetch(`/api/admin/books/${bookId}/cover`, {
                             method: "POST",
                             headers: {
                                 "Authorization": getToken() ? `Bearer ${getToken()}` : "",
@@ -1353,10 +1379,11 @@ function initAdminPage() {
                             return resp.json();
                         });
 
-                        alert("Обложка загружена");
+                        msg.textContent = "Обложка обновлена";
                         await loadBooks();
                     } catch (err) {
-                        alert("Ошибка: " + err.message);
+                        msg.textContent = err.message;
+                        msg.classList.add("message_error");
                     }
                 });
             });

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -1,126 +1,201 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div id="admin-root">
-    <h1>Админ-панель</h1>
+<div id="admin-root" class="admin-page">
+    <div class="admin-hero panel">
+        <div>
+            <p class="eyebrow">Управление магазином</p>
+            <h1>Админ-панель</h1>
+            <p class="text-muted">Работайте с каталогом, пользователями и заказами в одном месте.</p>
+        </div>
+        <div class="admin-hero__meta">
+            <div class="admin-chip">Каталог</div>
+            <div class="admin-chip">Клиенты</div>
+            <div class="admin-chip">Логистика</div>
+        </div>
+    </div>
 
-    <p id="admin-check-msg">Проверка прав администратора...</p>
+    <p id="admin-check-msg" class="admin-status">Проверка прав администратора...</p>
 
-    <div id="admin-content" style="display: none;">
-        <nav class="admin-nav">
-            <button data-section="books">Книги</button>
-            <button data-section="orders">Заказы</button>
-            <button data-section="users">Пользователи</button>
-            <button data-section="genres">Жанры</button>
-            <button data-section="authors">Авторы</button>
-            <button data-section="publishers">Издательства</button>
-        </nav>
+    <div id="admin-content" class="admin-layout" style="display: none;">
+        <aside class="admin-sidebar panel" aria-label="Навигация по разделам админ-панели">
+            <p class="admin-sidebar__title">Разделы</p>
+            <nav class="admin-nav">
+                <button data-section="books" class="admin-nav__btn is-active">Книги</button>
+                <button data-section="orders" class="admin-nav__btn">Заказы</button>
+                <button data-section="users" class="admin-nav__btn">Пользователи</button>
+                <button data-section="genres" class="admin-nav__btn">Жанры</button>
+                <button data-section="authors" class="admin-nav__btn">Авторы</button>
+                <button data-section="publishers" class="admin-nav__btn">Издательства</button>
+            </nav>
+        </aside>
 
-        <section id="admin-section-books" class="admin-section">
-            <h2>Книги</h2>
-            <div id="admin-books-list">Загрузка...</div>
+        <div class="admin-sections">
+            <section id="admin-section-books" class="admin-section panel">
+                <div class="admin-section__header">
+                    <div>
+                        <p class="eyebrow">Каталог</p>
+                        <h2>Книги</h2>
+                        <p class="text-muted">Обновляйте карточки книг и создавайте новые позиции.</p>
+                    </div>
+                </div>
 
-            <h3>Создать книгу</h3>
-            <form id="admin-book-create-form" class="form">
-                <label>
-                    Название
-                    <input type="text" name="title" required>
-                </label>
-                <label>
-                    Цена
-                    <input type="number" name="price" step="0.01" required>
-                </label>
-                <label>
-                    Год издания
-                    <input type="number" name="publication_year">
-                </label>
-                <label>
-                    Кол-во страниц
-                    <input type="number" name="pages">
-                </label>
-                <label>
-                    Жанр
-                    <input type="text" name="genre_name" list="admin-genre-options" placeholder="Начните вводить жанр">
-                    <datalist id="admin-genre-options"></datalist>
-                </label>
-                <label>
-                    Авторы (через запятую)
-                    <input type="text" name="author_names" list="admin-author-options" placeholder="Например: Имя Автора, Другой Автор">
-                    <datalist id="admin-author-options"></datalist>
-                </label>
-                <label>
-                    Издательство
-                    <input type="text" name="publisher_name" list="admin-publisher-options" placeholder="Начните вводить издательство">
-                    <datalist id="admin-publisher-options"></datalist>
-                </label>
-                <!-- НОВОЕ ПОЛЕ -->
-                <label>
-                    Обложка
-                    <input type="file" name="cover" id="admin-book-create-cover" accept="image/*">
-                </label>
+                <div class="admin-grid">
+                    <div class="admin-card">
+                        <div class="admin-card__header">
+                            <div>
+                                <p class="eyebrow">Новая позиция</p>
+                                <h3>Добавить книгу</h3>
+                            </div>
+                            <p class="text-muted">Заполните основные поля и загрузите обложку.</p>
+                        </div>
 
-                <button type="submit">Создать</button>
-            </form>
-            <div id="admin-book-create-msg" class="message"></div>
-        </section>
+                        <form id="admin-book-create-form" class="form admin-form">
+                            <div class="admin-form__grid">
+                                <div class="form__field">
+                                    <label class="form__label">Название</label>
+                                    <input class="input" type="text" name="title" required placeholder="Например, Улисс">
+                                </div>
+                                <div class="form__field">
+                                    <label class="form__label">Цена</label>
+                                    <input class="input" type="number" name="price" step="0.01" min="0" required placeholder="990">
+                                </div>
+                                <div class="form__field">
+                                    <label class="form__label">Год издания</label>
+                                    <input class="input" type="number" name="publication_year" placeholder="2024">
+                                </div>
+                                <div class="form__field">
+                                    <label class="form__label">Кол-во страниц</label>
+                                    <input class="input" type="number" name="pages" placeholder="320">
+                                </div>
+                                <div class="form__field">
+                                    <label class="form__label">Жанр</label>
+                                    <input class="input" type="text" name="genre_name" list="admin-genre-options" placeholder="Начните вводить жанр">
+                                    <datalist id="admin-genre-options"></datalist>
+                                </div>
+                                <div class="form__field">
+                                    <label class="form__label">Авторы</label>
+                                    <input class="input" type="text" name="author_names" list="admin-author-options" placeholder="Имя Автора, Другой Автор">
+                                    <datalist id="admin-author-options"></datalist>
+                                    <p class="form__hint">Укажите несколько авторов через запятую</p>
+                                </div>
+                                <div class="form__field">
+                                    <label class="form__label">Издательство</label>
+                                    <input class="input" type="text" name="publisher_name" list="admin-publisher-options" placeholder="Начните вводить издательство">
+                                    <datalist id="admin-publisher-options"></datalist>
+                                </div>
+                                <div class="form__field">
+                                    <label class="form__label">Обложка</label>
+                                    <input class="input" type="file" name="cover" id="admin-book-create-cover" accept="image/*">
+                                    <p class="form__hint">PNG или JPG, до 5 МБ</p>
+                                </div>
+                            </div>
 
-        <section id="admin-section-orders" class="admin-section" style="display:none;">
-            <h2>Заказы</h2>
-            <div id="admin-orders-list">Загрузка...</div>
-        </section>
+                            <div class="form__actions">
+                                <button type="submit" class="btn">Создать</button>
+                                <p id="admin-book-create-msg" class="form__message"></p>
+                            </div>
+                        </form>
+                    </div>
 
-        <section id="admin-section-users" class="admin-section" style="display:none;">
-            <h2>Пользователи</h2>
-            <div id="admin-users-list">Загрузка...</div>
-        </section>
+                    <div class="admin-card">
+                        <div class="admin-card__header">
+                            <div>
+                                <p class="eyebrow">Каталог</p>
+                                <h3>Список книг</h3>
+                            </div>
+                            <p class="text-muted">Редактируйте данные и обложки непосредственно в таблице.</p>
+                        </div>
+                        <div id="admin-books-list">Загрузка...</div>
+                    </div>
+                </div>
+            </section>
 
-        <section id="admin-section-genres" class="admin-section" style="display:none;">
-            <h2>Жанры</h2>
-            <div id="admin-genres-list">Загрузка...</div>
+            <section id="admin-section-orders" class="admin-section panel" style="display:none;">
+                <div class="admin-section__header">
+                    <p class="eyebrow">Продажи</p>
+                    <h2>Заказы</h2>
+                    <p class="text-muted">Отслеживайте статусы и суммы заказов.</p>
+                </div>
+                <div id="admin-orders-list">Загрузка...</div>
+            </section>
 
-            <h3>Создать жанр</h3>
-            <form id="admin-genre-create-form" class="form">
-                <label>
-                    Название
-                    <input type="text" name="name" required>
-                </label>
+            <section id="admin-section-users" class="admin-section panel" style="display:none;">
+                <div class="admin-section__header">
+                    <p class="eyebrow">Клиенты</p>
+                    <h2>Пользователи</h2>
+                    <p class="text-muted">Управляйте правами и статусами аккаунтов.</p>
+                </div>
+                <div id="admin-users-list">Загрузка...</div>
+            </section>
 
-                <button type="submit">Создать</button>
-            </form>
-            <div id="admin-genre-create-msg" class="message"></div>
-        </section>
+            <section id="admin-section-genres" class="admin-section panel" style="display:none;">
+                <div class="admin-section__header">
+                    <p class="eyebrow">Таксономия</p>
+                    <h2>Жанры</h2>
+                    <p class="text-muted">Добавляйте и правьте жанры, чтобы каталог оставался точным.</p>
+                </div>
 
-        <section id="admin-section-authors" class="admin-section" style="display:none;">
-            <h2>Авторы</h2>
-            <div id="admin-authors-list">Загрузка...</div>
+                <div id="admin-genres-list">Загрузка...</div>
 
-            <h3>Создать автора</h3>
-            <form id="admin-author-create-form" class="form">
-                <label>
-                    Полное имя
-                    <input type="text" name="full_name" required>
-                </label>
+                <div class="admin-card admin-card_inline">
+                    <form id="admin-genre-create-form" class="form admin-form">
+                        <div class="form__field">
+                            <label class="form__label">Название жанра</label>
+                            <input class="input" type="text" name="name" required placeholder="Например, Фантастика">
+                        </div>
+                        <div class="form__actions">
+                            <button type="submit" class="btn btn_ghost">Создать жанр</button>
+                            <p id="admin-genre-create-msg" class="form__message"></p>
+                        </div>
+                    </form>
+                </div>
+            </section>
 
-                <button type="submit">Создать</button>
-            </form>
-            <div id="admin-author-create-msg" class="message"></div>
-        </section>
+            <section id="admin-section-authors" class="admin-section panel" style="display:none;">
+                <div class="admin-section__header">
+                    <p class="eyebrow">Экспертиза</p>
+                    <h2>Авторы</h2>
+                    <p class="text-muted">Держите карточки авторов в порядке.</p>
+                </div>
+                <div id="admin-authors-list">Загрузка...</div>
 
-        <section id="admin-section-publishers" class="admin-section" style="display:none;">
-            <h2>Издательства</h2>
-            <div id="admin-publishers-list">Загрузка...</div>
+                <div class="admin-card admin-card_inline">
+                    <form id="admin-author-create-form" class="form admin-form">
+                        <div class="form__field">
+                            <label class="form__label">Полное имя</label>
+                            <input class="input" type="text" name="full_name" required placeholder="Имя Фамилия">
+                        </div>
+                        <div class="form__actions">
+                            <button type="submit" class="btn btn_ghost">Создать автора</button>
+                            <p id="admin-author-create-msg" class="form__message"></p>
+                        </div>
+                    </form>
+                </div>
+            </section>
 
-            <h3>Создать издательство</h3>
-            <form id="admin-publisher-create-form" class="form">
-                <label>
-                    Название
-                    <input type="text" name="name" required>
-                </label>
+            <section id="admin-section-publishers" class="admin-section panel" style="display:none;">
+                <div class="admin-section__header">
+                    <p class="eyebrow">Партнёры</p>
+                    <h2>Издательства</h2>
+                    <p class="text-muted">Ведите список издательств для каталога.</p>
+                </div>
+                <div id="admin-publishers-list">Загрузка...</div>
 
-                <button type="submit">Создать</button>
-            </form>
-            <div id="admin-publisher-create-msg" class="message"></div>
-        </section>
+                <div class="admin-card admin-card_inline">
+                    <form id="admin-publisher-create-form" class="form admin-form">
+                        <div class="form__field">
+                            <label class="form__label">Название</label>
+                            <input class="input" type="text" name="name" required placeholder="Название издательства">
+                        </div>
+                        <div class="form__actions">
+                            <button type="submit" class="btn btn_ghost">Создать издательство</button>
+                            <p id="admin-publisher-create-msg" class="form__message"></p>
+                        </div>
+                    </form>
+                </div>
+            </section>
+        </div>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- redesign admin dashboard layout with hero, sidebar navigation, and styled sections
- refresh book creation and editing forms with consistent inputs and integrated cover upload
- add admin-focused styles for tables, cards, and cover management

## Testing
- python -m compileall app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c5d6027988323847dbceb8dd11e5c)