### PR TITLE
Display book descriptions directly on catalog cards

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -414,6 +414,21 @@ body.drawer-open {
     align-items: stretch;
     border: 1px solid var(--color-border);
     height: 100%;
+    text-decoration: none;
+    color: inherit;
+    transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+    cursor: pointer;
+}
+
+.card:hover {
+    box-shadow: var(--shadow-lg);
+    transform: translateY(-2px);
+    border-color: rgba(76, 81, 191, 0.2);
+}
+
+.card:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(76, 81, 191, 0.35), var(--shadow-lg);
 }
 
 .card__top {
@@ -493,10 +508,15 @@ body.drawer-open {
     color: var(--color-text);
 }
 
-.card__hint {
+.card__description {
     margin: 0;
     color: var(--color-text-muted);
     font-size: 14px;
+    line-height: 1.5;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 .card__footer {
@@ -509,11 +529,6 @@ body.drawer-open {
 
 .card__footer .card__price {
     margin-right: var(--space-sm);
-}
-
-.card__actions {
-    display: flex;
-    gap: var(--space-xs);
 }
 
 .catalog-filters {

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -417,9 +417,28 @@ async function initIndexPage() {
                         : "Не указан";
                 const genre = b.genre_name || "Не указан";
                 const publisher = b.publisher_name || "Не указано";
+                const descriptionText =
+                    b.description?.trim() || "Описание недоступно.";
+                const safeDescription = descriptionText.replace(/[&<>'"]/g, (ch) => {
+                    switch (ch) {
+                        case "&":
+                            return "&amp;";
+                        case "<":
+                            return "&lt;";
+                        case ">":
+                            return "&gt;";
+                        case '"':
+                            return "&quot;";
+                        case "'":
+                            return "&#39;";
+                        default:
+                            return ch;
+                    }
+                });
 
-                const card = document.createElement("div");
+                const card = document.createElement("a");
                 card.className = "card";
+                card.href = `/books/${b.book_id}`;
                 card.setAttribute("role", "listitem");
                 card.setAttribute("aria-label", `${b.title}. Цена ${b.price} ₽`);
 
@@ -443,14 +462,11 @@ async function initIndexPage() {
                                     <p class="card__detail"><strong>Издательство:</strong> ${publisher}</p>
                                 </div>
                             </div>
-                            <p class="card__hint">Перейдите в карточку, чтобы прочитать описание и добавить книгу в корзину.</p>
+                            <p class="card__description">${safeDescription}</p>
                         </div>
                     </div>
                     <div class="card__footer">
                         <div class="card__price">${b.price} ₽</div>
-                        <div class="card__actions">
-                            <a class="btn btn_secondary" href="/books/${b.book_id}">Подробнее</a>
-                        </div>
                     </div>
                 `;
                 listEl.appendChild(card);


### PR DESCRIPTION
## Summary
- replace the catalog card hint with the book description and clamp it to fit the layout
- make the entire catalog card link to the book page and remove the extra detail button
- adjust card styling for hover/focus feedback on the new clickable card layout

## Testing
- pytest *(fails: missing python-multipart dependency; installation blocked by proxy)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c6cf705dc832392e9c4391562cf7f)